### PR TITLE
Remove bottom border on girl sections

### DIFF
--- a/src/layouts/girls.scss
+++ b/src/layouts/girls.scss
@@ -9,7 +9,6 @@
   background-size: cover;
   overflow: hidden;
   width: 100%;
-  border-bottom: solid 2px #eee;
 
   /*
     Alternating the position of


### PR DESCRIPTION
## Kill the evil bottom border

This thing has been around since the beginning, and we're finally gonna axe it

#### Why you made the changes:

- It looks bad (subjective)
- It adds a dozen or so px to the page height